### PR TITLE
Changed targetted .net core framework version

### DIFF
--- a/EdgeModules/modules/DirectMethodReceiver/DirectMethodReceiver.csproj
+++ b/EdgeModules/modules/DirectMethodReceiver/DirectMethodReceiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.2|AnyCPU'">

--- a/EdgeModules/modules/DirectMethodReceiver/Dockerfile.amd64
+++ b/EdgeModules/modules/DirectMethodReceiver/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./

--- a/EdgeModules/modules/DirectMethodReceiver/Dockerfile.amd64.debug
+++ b/EdgeModules/modules/DirectMethodReceiver/Dockerfile.amd64.debug
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-runtime-stretch-slim AS base
+FROM microsoft/dotnet:2.1-runtime-stretch-slim AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends unzip procps && \

--- a/EdgeModules/modules/DirectMethodReceiver/Dockerfile.arm32v7
+++ b/EdgeModules/modules/DirectMethodReceiver/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./

--- a/EdgeModules/modules/DirectMethodReceiver/Dockerfile.windows-amd64
+++ b/EdgeModules/modules/DirectMethodReceiver/Dockerfile.windows-amd64
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY . ./
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.2-runtime-nanoserver-1809
+FROM microsoft/dotnet:2.1-runtime-nanoserver-1809
 WORKDIR /app
 COPY --from=build-env /app/out ./
 ENTRYPOINT ["dotnet", "DirectMethodReceiver.dll"]

--- a/EdgeModules/modules/DirectMethodReceiver/Dockerfile.windows-amd64
+++ b/EdgeModules/modules/DirectMethodReceiver/Dockerfile.windows-amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./

--- a/EdgeModules/modules/MessageForwarder/MessageForwarder.csproj
+++ b/EdgeModules/modules/MessageForwarder/MessageForwarder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.2|AnyCPU'">


### PR DESCRIPTION
Changed framework to target .net core 2.1 (LTS version which Azure IoT Edge is depending on).

## Purpose
Since Azure IoT Edge modules are normally targetted on the .net core 2.1 framework, targetting the modules on .net core 2.2 is giving a lot of troubles to get them compiled. Changing the project targetted framework to 2.1 fixes all issues and compiles functional modules.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Compile within VS Code
* See succesful build
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Modules work as supposed.

## Other Information
<!-- Add any other helpful information that may be needed here. -->